### PR TITLE
fix: add line close and save history before os.Exit(0)

### DIFF
--- a/redis-cli.go
+++ b/redis-cli.go
@@ -32,7 +32,7 @@ var (
 	client *goredis.Client
 )
 
-//output
+// output
 const (
 	stdMode = iota
 	rawMode
@@ -106,6 +106,9 @@ func repl() {
 			if cmd == "help" || cmd == "?" {
 				printHelp(cmds)
 			} else if cmd == "quit" || cmd == "exit" {
+				saveHistory()
+				line.Close()
+
 				os.Exit(0)
 			} else if cmd == "clear" {
 				println("Please use Ctrl + L instead")


### PR DESCRIPTION
My pr is mostly for issue resolution: https://github.com/holys/redis-cli/issues/12.

The issue mentions that when typing quit, redis-cli exits normally and returns to the user's terminal, but when we typing any command, it will not show up because it's broken.

So I had to look in the project code to find out what happens when I type quit. All right I found the following code and I compared it to the official redis cli. But unfortunately, they both call exit(0) .

go version redis-cli:

~~~go
else if cmd == "quit" || cmd == "exit" {
  os.Exit(0)
}
~~~

official redis-cli:

[redis-cli.c](https://github.com/redis/redis/blob/unstable/src/redis-cli.c#L3425)

~~~c
if (strcasecmp(argv[0],"quit") == 0 ||
    strcasecmp(argv[0],"exit") == 0)
{
    exit(0);
}
~~~


So the problem is that calling `os.Exit(0)` in Go exits directly without executing the defer function, and I made the following changes and tried to solve the problem.

~~~go
else if cmd == "quit" || cmd == "exit" {
	saveHistory()
        line.Close()

	os.Exit(0)
}
~~~

Before:
![before](https://github.com/holys/redis-cli/assets/85121496/f5567fd8-1356-4f0e-bf39-80f51a183c54)

After:
![after](https://github.com/holys/redis-cli/assets/85121496/33ff6aab-8e42-4dd8-816a-7c224e7bf11a)

